### PR TITLE
Make it easier to add commands that make WebDriver based requests (#6317)

### DIFF
--- a/examples/wdio/jasmine/foo.spec.js
+++ b/examples/wdio/jasmine/foo.spec.js
@@ -1,0 +1,6 @@
+describe('webdriver.io page', () => {
+    it('should have the right title', () => {
+        browser.url('https://webdriver.io')
+        expect(browser).toHaveTitle('WebdriverIO · Next-gen browser and mobile automation test framework for Node.js | WebdriverIO')
+    })
+})

--- a/examples/wdio/jasmine/wdio.conf.js
+++ b/examples/wdio/jasmine/wdio.conf.js
@@ -5,13 +5,11 @@ exports.config = {
     /**
      * server configurations
      */
-    hostname: 'localhost',
-    port: 4444,
 
     /**
      * specify test files
      */
-    specs: [path.resolve(__dirname, 'jasmine.spec.js')],
+    specs: [[path.resolve(__dirname, '*.spec.js')]],
 
     /**
      * capabilities

--- a/examples/wdio/multiremote/fooo.test.js
+++ b/examples/wdio/multiremote/fooo.test.js
@@ -1,0 +1,38 @@
+describe('multiremote example', () => {
+    it('should open chat application', () => {
+        browser.url('https://socketio-chat-h9jt.herokuapp.com/')
+    })
+
+    it('should login the browser A', () => {
+        const nameInput = browserA.$('.usernameInput')
+        nameInput.addValue('Browser A')
+        browserA.keys('Enter')
+    })
+
+    it('should login the browser B', () => {
+        const nameInput = browserB.$('.usernameInput')
+        nameInput.addValue('Browser B')
+        browserB.keys('Enter')
+    })
+
+    it('should post something in browserA', () => {
+        const msgElemBrowserA = browserA.$('.inputMessage')
+        msgElemBrowserA.addValue('Hey Whats up!')
+        browser.pause(1000)
+        browserA.keys('Enter')
+
+        msgElemBrowserA.addValue('My name is Edgar')
+        browserA.keys('Enter')
+        browser.pause(200)
+    })
+
+    it('should read the message in browserB', () => {
+        const msgElemBrowserB = browserB.$('.inputMessage')
+        const chatLineBrowserB = browserB.$('.messageBody*=My name is')
+        const message = chatLineBrowserB.getText()
+        const name = message.slice(11)
+        msgElemBrowserB.addValue(`Hello ${name}! How are you today?`)
+        browserB.keys('Enter')
+        browser.pause(5000)
+    })
+})

--- a/examples/wdio/multiremote/wdio.conf.js
+++ b/examples/wdio/multiremote/wdio.conf.js
@@ -2,27 +2,22 @@ const path = require('path')
 
 exports.config = {
     /**
-     * server configurations
-     */
-    hostname: 'localhost',
-
-    /**
      * specify test files
      */
-    specs: [path.resolve(__dirname, 'mocha.test.js')],
+    specs: [
+        [path.resolve(__dirname, '*.test.js')]
+    ],
 
     /**
      * capabilities
      */
     capabilities: {
         browserA: {
-            port: 4444,
             capabilities: {
                 browserName: 'chrome'
             }
         },
         browserB: {
-            port: 4445,
             capabilities: {
                 browserName: 'chrome'
             }

--- a/foo.txt
+++ b/foo.txt
@@ -1,0 +1,125 @@
+
+> webdriverio-monorepo@ test:smoke /Users/christianbromann/Sites/WebdriverIO/webdriverio
+> ts-node ./tests/smoke.runner.js "mochaSpecGrouping"
+
+
+Running smoke tests...
+
+
+Execution of 1 spec files started at 2021-03-18T10:11:03.158Z
+
+[0-0] RUNNING in chrome - /tests/mocha/test-empty.js, /tests/mocha/test-middleware.js, /tests/mocha/test-waitForElement.js, /tests/mocha/test-skipped.js, /tests/mocha/test-skipped-grep.js
+[0-0] [
+  RunnerStats {
+    type: 'runner',
+    start: 2021-03-18T10:11:06.274Z,
+    _duration: 0,
+    cid: '0-0',
+    capabilities: {
+      acceptInsecureCerts: false,
+      browserName: 'firefox',
+      browserVersion: 64,
+      pageLoadStrategy: 'normal',
+      platformName: 'mac',
+      platformVersion: '17.7.0',
+      rotatable: false,
+      setWindowRect: true,
+      timeouts: [Array],
+      unhandledPromptBehavior: 'dismiss and notify',
+      'moz:accessibilityChecks': false,
+      'moz:geckodriverVersion': '0.23.0',
+      'moz:headless': false,
+      'moz:processID': 15867,
+      'moz:profile': '/var/folders/ns/8mj2mh0x27b_gsdddy1knnsm0000gn/T/rust_mozprofile.yUuH0ktcRJPN',
+      'moz:shutdownTimeout': 60000,
+      'moz:useNonSpecCompliantPointerOrigin': false,
+      'moz:webdriverClick': true,
+      sessionId: '898d35a7-a82d-4dfc-b0cc-e4b7e9d1f1af'
+    },
+    sanitizedCapabilities: 'firefox.64.mac',
+    config: {
+      protocol: 'http',
+      hostname: 'localhost',
+      port: 4444,
+      path: '/',
+      capabilities: [Object],
+      logLevel: 'trace',
+      outputDir: '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/helpers',
+      connectionRetryTimeout: 120000,
+      connectionRetryCount: 3,
+      logLevels: {},
+      transformRequest: [Function: default],
+      transformResponse: [Function: default],
+      strictSSL: true,
+      requestedCapabilities: [Object],
+      specs: [Array],
+      exclude: [],
+      suites: {},
+      bail: 0,
+      waitforInterval: 500,
+      waitforTimeout: 5000,
+      framework: 'mocha',
+      reporters: [Array],
+      services: [Array],
+      execArgv: [],
+      maxInstances: 100,
+      maxInstancesPerCapability: 100,
+      filesToWatch: [],
+      onPrepare: [],
+      onWorkerStart: [],
+      before: [Array],
+      beforeSession: [],
+      beforeSuite: [],
+      beforeHook: [],
+      beforeTest: [],
+      beforeCommand: [],
+      afterCommand: [],
+      afterTest: [],
+      afterHook: [],
+      afterSuite: [],
+      afterSession: [],
+      after: [],
+      onComplete: [],
+      onReload: [],
+      automationProtocol: 'webdriver'
+    },
+    specs: [
+      '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-empty.js',
+      '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-middleware.js',
+      '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-waitForElement.js',
+      '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-skipped.js',
+      '/Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-skipped-grep.js'
+    ],
+    sessionId: '898d35a7-a82d-4dfc-b0cc-e4b7e9d1f1af',
+    isMultiremote: false,
+    retry: 0
+  }
+]
+[0-0] PASSED in chrome - /tests/mocha/test-empty.js, /tests/mocha/test-middleware.js, /tests/mocha/test-waitForElement.js, /tests/mocha/test-skipped.js, /tests/mocha/test-skipped-grep.js
+
+ "spec" Reporter:
+------------------------------------------------------------------
+[firefox 64 mac #0-0] Spec: /Users/christianbromann/Sites/WebdriverIO/webdriverio/tests/mocha/test-empty.js
+[firefox 64 mac #0-0] Running: firefox (v64) on mac
+[firefox 64 mac #0-0] Session ID: 898d35a7-a82d-4dfc-b0cc-e4b7e9d1f1af
+[firefox 64 mac #0-0]
+[firefox 64 mac #0-0] empty test
+[firefox 64 mac #0-0]    [32m✓[39m should not be skipped
+[firefox 64 mac #0-0]
+[firefox 64 mac #0-0] Mocha smoke test
+[firefox 64 mac #0-0]     middleware
+[firefox 64 mac #0-0]        [32m✓[39m should wait for elements if not found immediately
+[firefox 64 mac #0-0]        [32m✓[39m should refetch stale elements
+[firefox 64 mac #0-0]
+[firefox 64 mac #0-0] Mocha smoke test
+[firefox 64 mac #0-0]    [32m✓[39m should be able to wait for an element
+[firefox 64 mac #0-0]
+[firefox 64 mac #0-0] [32m4 passing (5.6s)[39m
+
+
+Spec Files:	 1 passed, 1 total (100% completed) in 00:00:08 
+
+Smoke test successful
+
+All smoke tests passed!
+

--- a/packages/wdio-jasmine-framework/package.json
+++ b/packages/wdio-jasmine-framework/package.json
@@ -29,6 +29,7 @@
     "@wdio/logger": "7.0.0",
     "@wdio/types": "7.2.0",
     "@wdio/utils": "7.2.0",
+    "callsites": "^3.1.0",
     "expect-webdriverio": "^2.0.0",
     "jasmine": "3.6.4"
   },

--- a/packages/wdio-jasmine-framework/src/index.ts
+++ b/packages/wdio-jasmine-framework/src/index.ts
@@ -102,6 +102,19 @@ class JasmineAdapter {
          * enable expectHandler
          */
         jasmine.Spec.prototype.addExpectationResult = this.getExpectationResultHandler(jasmine)
+        Object.defineProperty(global, '__filename', {
+            get: function () {
+                // @ts-expect-error
+                let path = __stack[1].getFileName()
+                console.log('YPP', path)
+
+                try { //*nix OSes
+                    return path.match(/[^\/]+\/[^\/]+$/)[0]
+                } catch (error) { //Windows based OSes
+                    return path.match(/[^\\]+\\[^\\]+$/)[0]
+                }
+            }
+        })
 
         const hookArgsFn = (context: unknown): [unknown, unknown] => [{ ...(self._lastTest || {}) }, context]
 
@@ -142,7 +155,6 @@ class JasmineAdapter {
                 afterHook.push(emitHookEvent(fnName, 'end'))
             }
 
-            this._config.beforeTest
             runTestInFiberContext(
                 isTest,
                 isTest ? this._config.beforeTest : beforeHook,
@@ -249,6 +261,12 @@ class JasmineAdapter {
 
             this._jrunner.env.beforeAll(this.wrapHook('beforeSuite'))
             this._jrunner.env.afterAll(this.wrapHook('afterSuite'))
+
+            console.log(this._jrunner.env)
+
+            const runner = this._jrunner.env.currentRunner
+            // console.log(111, runner.specs())
+
 
             this._jrunner.onComplete(() => resolve(this._reporter.getFailedCount()))
             this._jrunner.execute()

--- a/packages/wdio-jasmine-framework/src/reporter.ts
+++ b/packages/wdio-jasmine-framework/src/reporter.ts
@@ -45,6 +45,8 @@ export default class JasmineReporter {
     }
 
     specStarted (test: jasmine.CustomReporterResult) {
+        console.log(test);
+
         this._testStart = new Date()
         const newTest: TestEvent = {
             type: 'test',

--- a/packages/wdio-reporter/src/index.ts
+++ b/packages/wdio-reporter/src/index.ts
@@ -49,6 +49,7 @@ export default class WDIOReporter extends EventEmitter {
         const rootSuite = new SuiteStats({
             title: '(root)',
             fullTitle: '(root)',
+            file: ''
         })
         this.currentSuites.push(rootSuite)
 

--- a/packages/wdio-reporter/src/stats/suite.ts
+++ b/packages/wdio-reporter/src/stats/suite.ts
@@ -9,7 +9,7 @@ export interface Suite {
     parent?: string
     fullTitle: string
     pending?: boolean
-    fil?: string
+    file: string
     duration?: number
     cid?: string
     specs?: string[]
@@ -26,6 +26,7 @@ export default class SuiteStats extends RunnableStats {
     cid?: string
     title: string
     fullTitle: string
+    file: string
     tags?: string[] | Tag[]
     tests: TestStats[] = []
     hooks: HookStats[] = []
@@ -43,6 +44,7 @@ export default class SuiteStats extends RunnableStats {
         this.title = suite.title
         this.fullTitle = suite.fullTitle
         this.tags = suite.tags
+        this.file = suite.file
         /**
          * only Cucumber
          */

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -163,14 +163,7 @@ export default class SpecReporter extends WDIOReporter {
         const combo = this.getEnviromentCombo(runner.capabilities, undefined, runner.isMultiremote).trim()
 
         // Spec file name and enviroment information
-        const output = [
-            'Spec' + (runner.specs.length === 1 ? `: ${runner.specs[0]}` : 's:'),
-            ...(runner.specs.length > 1
-                ? runner.specs.map((spec) => '\t- ' + spec.replace(process.cwd(), ''))
-                : []
-            ),
-            `Running: ${combo}`
-        ]
+        const output = [`Running: ${combo}`]
 
         /**
          * print session ID if not multiremote
@@ -209,6 +202,7 @@ export default class SpecReporter extends WDIOReporter {
     getResultDisplay () {
         const output = []
         const suites = this.getOrderedSuites()
+        const specFileReferences: string[] = []
 
         for (const suite of suites) {
             // Don't do anything if a suite has no tests or sub suites
@@ -218,6 +212,12 @@ export default class SpecReporter extends WDIOReporter {
 
             // Get the indent/starting point for this suite
             const suiteIndent = this.indent(suite.uid)
+
+            // Display file path of spec
+            if (!specFileReferences.includes(suite.file)) {
+                output.push(`${suiteIndent}» ${suite.file.replace(process.cwd(), '')}`)
+                specFileReferences.push(suite.file)
+            }
 
             // Display the title of the suite
             output.push(`${suiteIndent}${suite.title}`)

--- a/packages/wdio-spec-reporter/src/index.ts
+++ b/packages/wdio-spec-reporter/src/index.ts
@@ -164,7 +164,11 @@ export default class SpecReporter extends WDIOReporter {
 
         // Spec file name and enviroment information
         const output = [
-            `Spec: ${runner.specs[0]}`,
+            'Spec' + (runner.specs.length === 1 ? `: ${runner.specs[0]}` : 's:'),
+            ...(runner.specs.length > 1
+                ? runner.specs.map((spec) => '\t- ' + spec.replace(process.cwd(), ''))
+                : []
+            ),
             `Running: ${combo}`
         ]
 

--- a/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
+++ b/packages/wdio-spec-reporter/tests/__fixtures__/testdata.ts
@@ -16,6 +16,7 @@ export const SUITES = {
     [suiteIds[0]]: {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'foo1',
@@ -32,6 +33,7 @@ export const SUITES = {
     [suiteIds[1]]: {
         uid: suiteIds[1],
         title: suiteIds[1].slice(0, -1),
+        file: '/bar/foo/loo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'some test1',
@@ -59,6 +61,7 @@ export const SUITES = {
     [suiteIds[2]]: {
         uid: suiteIds[2],
         title: suiteIds[2].slice(0, -1),
+        file: '/bar/loo/foo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'foo bar baz1',
@@ -83,6 +86,7 @@ export const SUITES_WITH_DATA_TABLE = {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
         description: '\tSome important\ndescription to read!',
+        file: '/foo/bar/loo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'foo1',
@@ -137,6 +141,7 @@ export const SUITES_MULTIPLE_ERRORS = {
     [suiteIds[0]]: {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'foo1',
@@ -153,6 +158,7 @@ export const SUITES_MULTIPLE_ERRORS = {
     [suiteIds[1]]: {
         uid: suiteIds[1],
         title: suiteIds[1].slice(0, -1),
+        file: '/bar/foo/loo.e2e.js',
         hooks: [],
         tests: [{
             uid: 'some test1',
@@ -183,6 +189,7 @@ export const SUITES_NO_TESTS = {
     [suiteIds[0]]: {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
         tests: [],
         suites: [],
         hooks: [],
@@ -194,6 +201,7 @@ export const SUITES_NO_TESTS_WITH_HOOK_ERROR = {
     [suiteIds[0]]: {
         uid: suiteIds[0],
         title: suiteIds[0].slice(0, -1),
+        file: '/foo/bar/loo.e2e.js',
         tests: [],
         suites: [],
         hooks: [{

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SpecReporter getHeaderDisplay should list multiple specs 1`] = `
+Array [
+  "Specs:",
+  "	- /foo/bar/baz.js",
+  "	- /foo/bar/loo.js",
+  "	- /bar/foo/baz.js",
+  "Running: loremipsum (v50) on Windows 10",
+  "Session ID: foobar",
+]
+`;
+
 exports[`SpecReporter getResultDisplay should not print if data table format is not given 1`] = `
 Array [
   "Foo test",

--- a/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
+++ b/packages/wdio-spec-reporter/tests/__snapshots__/index.test.ts.snap
@@ -2,17 +2,27 @@
 
 exports[`SpecReporter getHeaderDisplay should list multiple specs 1`] = `
 Array [
-  "Specs:",
-  "	- /foo/bar/baz.js",
-  "	- /foo/bar/loo.js",
-  "	- /bar/foo/baz.js",
   "Running: loremipsum (v50) on Windows 10",
   "Session ID: foobar",
 ]
 `;
 
+exports[`SpecReporter getHeaderDisplay should validate header output 1`] = `
+Array [
+  "Running: loremipsum (v50) on Windows 10",
+  "Session ID: foobar",
+]
+`;
+
+exports[`SpecReporter getHeaderDisplay should validate header output in multiremote 1`] = `
+Array [
+  "Running: MultiremoteBrowser on chrome, firefox",
+]
+`;
+
 exports[`SpecReporter getResultDisplay should not print if data table format is not given 1`] = `
 Array [
+  "» /foo/bar/loo.e2e.js",
   "Foo test",
   "grey Some important",
   "grey description to read!",
@@ -25,6 +35,7 @@ Array [
 
 exports[`SpecReporter getResultDisplay should not print if data table is empty 1`] = `
 Array [
+  "» /foo/bar/loo.e2e.js",
   "Foo test",
   "grey Some important",
   "grey description to read!",
@@ -37,6 +48,7 @@ Array [
 
 exports[`SpecReporter getResultDisplay should print data tables 1`] = `
 Array [
+  "» /foo/bar/loo.e2e.js",
   "Foo test",
   "grey Some important",
   "grey description to read!",
@@ -53,15 +65,18 @@ Array [
 
 exports[`SpecReporter getResultDisplay should validate the result output with tests 1`] = `
 Array [
+  "» /foo/bar/loo.e2e.js",
   "Foo test",
   "   green ✓ foo",
   "   green ✓ bar",
   "",
+  "» /bar/foo/loo.e2e.js",
   "Bar test",
   "   green ✓ some test",
   "   red ✖ a failed test",
   "   red ✖ a failed test with no stack",
   "",
+  "» /bar/loo/foo.e2e.js",
   "Baz test",
   "   green ✓ foo bar baz",
   "   cyan - a skipped test",
@@ -75,18 +90,20 @@ exports[`SpecReporter printReport with normal setup should print jobs of all ins
 Array [
   Array [
     "------------------------------------------------------------------
-[MultiremoteBrowser #0-0] Spec: /foo/bar/baz.js
 [MultiremoteBrowser #0-0] Running: MultiremoteBrowser on ,
 [MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] » /foo/bar/loo.e2e.js
 [MultiremoteBrowser #0-0] Foo test
 [MultiremoteBrowser #0-0]    green ✓ foo
 [MultiremoteBrowser #0-0]    green ✓ bar
 [MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] » /bar/foo/loo.e2e.js
 [MultiremoteBrowser #0-0] Bar test
 [MultiremoteBrowser #0-0]    green ✓ some test
 [MultiremoteBrowser #0-0]    red ✖ a failed test
 [MultiremoteBrowser #0-0]    red ✖ a failed test with no stack
 [MultiremoteBrowser #0-0]
+[MultiremoteBrowser #0-0] » /bar/loo/foo.e2e.js
 [MultiremoteBrowser #0-0] Baz test
 [MultiremoteBrowser #0-0]    green ✓ foo bar baz
 [MultiremoteBrowser #0-0]    cyan - a skipped test
@@ -113,19 +130,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -151,19 +170,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -189,19 +210,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -222,19 +245,21 @@ Array [
   ],
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -260,19 +285,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -298,19 +325,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -336,19 +365,21 @@ exports[`SpecReporter printReport with normal setup should print link to Sauce L
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test
@@ -374,19 +405,21 @@ exports[`SpecReporter printReport with normal setup should print the report to t
 Array [
   Array [
     "------------------------------------------------------------------
-[loremipsum 50 Windows 10 #0-0] Spec: /foo/bar/baz.js
 [loremipsum 50 Windows 10 #0-0] Running: loremipsum (v50) on Windows 10
 [loremipsum 50 Windows 10 #0-0] Session ID: foobar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /foo/bar/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Foo test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo
 [loremipsum 50 Windows 10 #0-0]    green ✓ bar
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/foo/loo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Bar test
 [loremipsum 50 Windows 10 #0-0]    green ✓ some test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test
 [loremipsum 50 Windows 10 #0-0]    red ✖ a failed test with no stack
 [loremipsum 50 Windows 10 #0-0]
+[loremipsum 50 Windows 10 #0-0] » /bar/loo/foo.e2e.js
 [loremipsum 50 Windows 10 #0-0] Baz test
 [loremipsum 50 Windows 10 #0-0]    green ✓ foo bar baz
 [loremipsum 50 Windows 10 #0-0]    cyan - a skipped test

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -293,10 +293,7 @@ describe('SpecReporter', () => {
     describe('getHeaderDisplay', () => {
         it('should validate header output', () => {
             const result = reporter.getHeaderDisplay(getRunnerConfig() as any)
-
-            expect(result.length).toBe(3)
-            expect(result[0]).toBe('Spec: /foo/bar/baz.js')
-            expect(result[1]).toBe('Running: loremipsum (v50) on Windows 10')
+            expect(result).toMatchSnapshot()
         })
 
         it('should list multiple specs', () => {
@@ -316,9 +313,7 @@ describe('SpecReporter', () => {
                     isMultiremote: true,
                 }))
 
-            expect(result.length).toBe(2)
-            expect(result[0]).toBe('Spec: /foo/bar/baz.js')
-            expect(result[1]).toBe('Running: MultiremoteBrowser on chrome, firefox')
+            expect(result).toMatchSnapshot()
         })
     })
 

--- a/packages/wdio-spec-reporter/tests/index.test.ts
+++ b/packages/wdio-spec-reporter/tests/index.test.ts
@@ -14,7 +14,7 @@ const reporter = new SpecReporter({})
 const defaultCaps = { browserName: 'loremipsum', version: 50, platform: 'Windows 10', sessionId: 'foobar' }
 const fakeSessionId = 'ba86cbcb70774ef8a0757c1702c3bdf9'
 const getRunnerConfig = (config: any = {}) => {
-    return Object.assign({}, RUNNER, {
+    return Object.assign(JSON.parse(JSON.stringify(RUNNER)), {
         capabilities: config.capabilities || defaultCaps,
         config,
         sessionId: fakeSessionId,
@@ -23,7 +23,7 @@ const getRunnerConfig = (config: any = {}) => {
 }
 
 describe('SpecReporter', () => {
-    let tmpReporter = null
+    let tmpReporter:SpecReporter
 
     beforeEach(() => {
         tmpReporter = new SpecReporter({})
@@ -297,6 +297,13 @@ describe('SpecReporter', () => {
             expect(result.length).toBe(3)
             expect(result[0]).toBe('Spec: /foo/bar/baz.js')
             expect(result[1]).toBe('Running: loremipsum (v50) on Windows 10')
+        })
+
+        it('should list multiple specs', () => {
+            const config = getRunnerConfig() as any
+            config.specs.push('/foo/bar/loo.js', '/bar/foo/baz.js')
+            const result = reporter.getHeaderDisplay(config)
+            expect(result).toMatchSnapshot()
         })
 
         it('should validate header output in multiremote', () => {

--- a/tests/smoke.runner.js
+++ b/tests/smoke.runner.js
@@ -357,6 +357,8 @@ const mochaSpecGrouping = async () => {
             specs: [
                 [
                     path.resolve(__dirname, 'mocha', 'test-empty.js'),
+                    path.resolve(__dirname, 'mocha', 'test-middleware.js'),
+                    path.resolve(__dirname, 'mocha', 'test-waitForElement.js'),
                     path.resolve(__dirname, 'mocha', 'test-skipped.js'),
                     path.resolve(__dirname, 'mocha', 'test-skipped-grep.js')
                 ]


### PR DESCRIPTION
This change updates the spec reporter to better show a list of specs rather than a single one, e.g.:

```
------------------------------------------------------------------
[firefox 64 mac #0-0] Specs:
[firefox 64 mac #0-0]     - /tests/mocha/test-empty.js
[firefox 64 mac #0-0]     - /tests/mocha/test-empty2.js
[firefox 64 mac #0-0]     - /tests/mocha/test-empty3.js
[firefox 64 mac #0-0] Running: firefox (v64) on mac
[firefox 64 mac #0-0] Session ID: 8f5a043e-adc6-4f52-b1f5-fd99b286e943
[firefox 64 mac #0-0]
[firefox 64 mac #0-0] empty test
[firefox 64 mac #0-0]    ✓ should not be skipped
[firefox 64 mac #0-0]
[firefox 64 mac #0-0] Mocha smoke test
[firefox 64 mac #0-0]     middleware
[firefox 64 mac #0-0]        ✓ should wait for elements if not found immediately
[firefox 64 mac #0-0]        ✓ should refetch stale elements
[firefox 64 mac #0-0]
[firefox 64 mac #0-0] Mocha smoke test
[firefox 64 mac #0-0]    ✓ should be able to wait for an element
[firefox 64 mac #0-0]
[firefox 64 mac #0-0] 4 passing (5.6s)
```

refs #6548